### PR TITLE
Style original questions and update Data Strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,10 @@
             margin-bottom: 0;
         }
 
+        .original-question-item {
+            background-color: #fff5e6; /* Subtle orange for original questions */
+        }
+
         .notes-area {
             width: 100%;
             min-height: 60px;
@@ -278,7 +282,7 @@
                 </div>
                 <div class="questions-container" id="data-strategy">
                     <div class="question-group">
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level opening">Opening</span>
                             <div class="question-text">What are the characteristics of a Data Warehouse - what makes it different from another type of database?</div>
                             <div class="question-competencies">
@@ -287,7 +291,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level lighter">Lighter</span>
                             <div class="question-text">What do people typically do with data before attempting analytics?</div>
                             <div class="question-competencies">
@@ -295,13 +299,71 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level heavier">Heavier</span>
-                            <div class="question-text">Discuss the trade-offs inherent in the CAP theorem.</div>
+                            <div class="question-text">Describe a time when you’ve been responsible for implementing a data strategy to support an analytics project… Given recent technology changes, would you approach the project differently if you could repeat it now?</div>
                             <div class="question-competencies">
                                 <span class="competency-tag solutioning">Solutioning</span>
-                                <span class="competency-tag risk">Risk Mitigation</span>
                                 <span class="competency-tag business">Knowing Your Business</span>
+                                <span class="competency-tag risk">Risk Mitigation</span>
+                                <span class="competency-tag project">Project Management</span>
+                                <span class="competency-tag communication">Customer Communication</span>
+                            </div>
+                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="category-card">
+                <div class="category-header" onclick="toggleCategory('databases')">
+                    <h2 class="category-title">2. Databases</h2>
+                    <button class="toggle-btn">Show Questions</button>
+                </div>
+                <div class="questions-container" id="databases">
+                    <div class="question-group">
+                        <div class="question-item original-question-item">
+                            <span class="question-level opening">Opening</span>
+                            <div class="question-text">Provide an example of unstructured data and describe the challenges it creates for analytics.</div>
+                            <div class="question-competencies">
+                                <span class="competency-tag solutioning">Solutioning</span>
+                                <span class="competency-tag business">Knowing Your Business</span>
+                            </div>
+                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
+                        </div>
+                        <div class="question-item original-question-item">
+                            <span class="question-level lighter">Lighter</span>
+                            <div class="question-text">What are the advantages of working with a database compared to data stored in file format?</div>
+                            <div class="question-competencies">
+                                <span class="competency-tag solutioning">Solutioning</span>
+                            </div>
+                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
+                        </div>
+                        <div class="question-item original-question-item">
+                            <span class="question-level heavier">Heavier</span>
+                            <div class="question-text">Can you describe the current state of the competitive market for database technologies?</div>
+                            <div class="question-competencies">
+                                <span class="competency-tag business">Knowing Your Business</span>
+                                <span class="competency-tag solutioning">Solutioning</span>
+                            </div>
+                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
+                        </div>
+                    </div>
+                    <div class="question-group">
+                        <div class="question-item">
+                            <span class="question-level opening">Opening</span>
+                            <div class="question-text">When would you choose a NoSQL database over a relational database for an analytics application, and why?</div>
+                            <div class="question-competencies">
+                                <span class="competency-tag solutioning">Solutioning</span>
+                                <span class="competency-tag business">Knowing Your Business</span>
+                            </div>
+                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
+                        </div>
+                        <div class="question-item">
+                            <span class="question-level lighter">Lighter</span>
+                            <div class="question-text">What is data normalization, and why is it important?</div>
+                            <div class="question-competencies">
+                                <span class="competency-tag solutioning">Solutioning</span>
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
@@ -316,7 +378,7 @@
                 </div>
                 <div class="questions-container" id="coding">
                     <div class="question-group">
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level opening">Opening</span>
                             <div class="question-text">What is your level of comfort with SQL, Python, R, Javascript or other scripting/coding languages?</div>
                             <div class="question-competencies">
@@ -324,7 +386,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level lighter">Lighter</span>
                             <div class="question-text">What is an API and why would you use it?</div>
                             <div class="question-competencies">
@@ -333,7 +395,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level heavier">Heavier</span>
                             <div class="question-text">Describe a (data) project that you delivered using scripts or code - what problem did you solve, why did you do it that way?</div>
                             <div class="question-competencies">
@@ -384,7 +446,7 @@
                 </div>
                 <div class="questions-container" id="organizations">
                     <div class="question-group">
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level opening">Opening</span>
                             <div class="question-text">Does responsibility for Analytics sit within the IT or the Business side of an organisation?</div>
                             <div class="question-competencies">
@@ -393,7 +455,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level lighter">Lighter</span>
                             <div class="question-text">Can you describe the ideal sales cycle for an analytics solution? On the customer side, who makes the purchase and why?</div>
                             <div class="question-competencies">
@@ -402,7 +464,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level heavier">Heavier</span>
                             <div class="question-text">Can you describe different strategies we might use that lead to successful purchase and adoption of analytics technology by a customer?</div>
                             <div class="question-competencies">
@@ -457,7 +519,7 @@
                 </div>
                 <div class="questions-container" id="security">
                     <div class="question-group">
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level opening">Opening</span>
                             <div class="question-text">Describe one or two methods of applying security to data.</div>
                             <div class="question-competencies">
@@ -466,7 +528,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level lighter">Lighter</span>
                             <div class="question-text">Can you explain the difference between authentication and authorization?</div>
                             <div class="question-competencies">
@@ -475,7 +537,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level heavier">Heavier</span>
                             <div class="question-text">What type of questions would a customer's Head of Security ask before allowing their sensitive data to be accessed by our technology?</div>
                             <div class="question-competencies">
@@ -528,7 +590,7 @@
                 </div>
                 <div class="questions-container" id="cloud">
                     <div class="question-group">
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level opening">Opening</span>
                             <div class="question-text">What deployment options are available for the Tableau platform - is it available in cloud, can it be deployed on-premise? What about SaaS?</div>
                             <div class="question-competencies">
@@ -537,7 +599,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level lighter">Lighter</span>
                             <div class="question-text">What are the advantages/disadvantages of deploying analytics software in the cloud?</div>
                             <div class="question-competencies">
@@ -547,7 +609,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level heavier">Heavier</span>
                             <div class="question-text">Can you describe the current state of play in the cloud computing industry - who are the major players and why do customers choose one or another?</div>
                             <div class="question-competencies">
@@ -598,7 +660,7 @@
                 </div>
                 <div class="questions-container" id="visualization">
                     <div class="question-group">
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level opening">Opening</span>
                             <div class="question-text">What is the role of visual perception and psychology in data visualisation?</div>
                             <div class="question-competencies">
@@ -607,7 +669,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level lighter">Lighter</span>
                             <div class="question-text">Please describe good or bad examples of data visualisation.</div>
                             <div class="question-competencies">
@@ -616,7 +678,7 @@
                             </div>
                             <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
                         </div>
-                        <div class="question-item">
+                        <div class="question-item original-question-item">
                             <span class="question-level heavier">Heavier</span>
                             <div class="question-text">How would you plan an enablement session for a group of finance analysts that have only ever worked with spreadsheets, persuading them to visualise data?</div>
                             <div class="question-competencies">
@@ -799,103 +861,3 @@
     </script>
 </body>
 </html>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                        <div class="question-item">
-                            <span class="question-level heavier">Heavier</span>
-                            <div class="question-text">Describe a time when you've been responsible for implementing a data strategy to support an analytics project. Given recent technology changes, would you approach the project differently if you could repeat it now?</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag solutioning">Solutioning</span>
-                                <span class="competency-tag business">Knowing Your Business</span>
-                                <span class="competency-tag risk">Risk Mitigation</span>
-                                <span class="competency-tag project">Project Management</span>
-                                <span class="competency-tag communication">Customer Communication</span>
-                            </div>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                    </div>
-                    <div class="question-group">
-                        <div class="question-item">
-                            <span class="question-level opening">Opening</span>
-                            <div class="question-text">How can an organization measure the ROI of its data strategy initiatives?</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag business">Knowing Your Business</span>
-                                <span class="competency-tag value-selling">Value Selling</span>
-                                <span class="competency-tag solutioning">Solutioning</span>
-                            </div>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                        <div class="question-item">
-                            <span class="question-level lighter">Lighter</span>
-                            <div class="question-text">What are common pitfalls to avoid when developing a data strategy?</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag risk">Risk Mitigation</span>
-                                <span class="competency-tag solutioning">Solutioning</span>
-                            </div>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                        <div class="question-item">
-                            <span class="question-level heavier">Heavier</span>
-                            <div class="question-text">Imagine a company wants to transition from a reactive to a proactive culture. Outline the key pillars of this transformation.</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag solutioning">Solutioning</span>
-                                <span class="competency-tag business">Knowing Your Business</span>
-                                <span class="competency-tag communication">Customer Communication</span>
-                                <span class="competency-tag project">Project Management</span>
-                            </div>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="category-card">
-                <div class="category-header" onclick="toggleCategory('databases')">
-                    <h2 class="category-title">2. Databases</h2>
-                    <button class="toggle-btn">Show Questions</button>
-                </div>
-                <div class="questions-container" id="databases">
-                    <div class="question-group">
-                        <div class="question-item">
-                            <span class="question-level opening">Opening</span>
-                            <div class="question-text">Provide an example of unstructured data and describe the challenges it creates for analytics.</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag solutioning">Solutioning</span>
-                                <span class="competency-tag business">Knowing Your Business</span>
-                            </div>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                        <div class="question-item">
-                            <span class="question-level lighter">Lighter</span>
-                            <div class="question-text">What are the advantages of working with a database compared to data stored in file format?</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag solutioning">Solutioning</span>
-                            </div>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                        <div class="question-item">
-                            <span class="question-level heavier">Heavier</span>
-                            <div class="question-text">Can you describe the current state of the competitive market for database technologies?</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag business">Knowing Your Business</span>
-                                <span class="competency-tag solutioning">Solutioning</span>
-                            </div>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                    </div>
-                    <div class="question-group">
-                        <div class="question-item">
-                            <span class="question-level opening">Opening</span>
-                            <div class="question-text">When would you choose a NoSQL database over a relational database for an analytics application, and why?</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag solutioning">Solutioning</span>
-                                <span class="competency-tag business">Knowing Your Business</span>
-                            </div>
-                            <textarea class="notes-area" placeholder="Quick notes for this question..."></textarea>
-                        </div>
-                        <div class="question-item">
-                            <span class="question-level lighter">Lighter</span>
-                            <div class="question-text">What is data normalization, and why is it important?</div>
-                            <div class="question-competencies">
-                                <span class="competency-tag solutioning">Solutioning</span>
-                            


### PR DESCRIPTION
This commit implements the following changes:

1.  Added a new CSS class `.original-question-item` with a subtle orange background (`#fff5e6`) to visually differentiate specified questions.
2.  Applied this new style to designated "original" questions in the following categories:
    - Data Strategy (also updated text and competencies for one question)
    - Databases
    - Coding/Scripting
    - Working with Large Organizations
    - Security
    - Cloud Computing
    - Visualizing Data

The primary goal was to ensure these specific questions are present and visually distinct.

Work on the following sections is pending:
- Analytics and AI
- Technical Curiosity

A final review of all changes was also planned before completing the work.